### PR TITLE
updated debug trait for Crontab

### DIFF
--- a/src/crontab.rs
+++ b/src/crontab.rs
@@ -4,7 +4,7 @@ use time::{Tm, now, now_utc};
 use times::{adv_month, adv_day, adv_hour, adv_minute};
 
 /// Represents a crontab schedule.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Crontab {
   /// The components parsed from a crontab schedule.
   pub schedule: ScheduleComponents,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,6 @@ mod times;
 // Exports
 pub use crontab::Crontab;
 pub use parsing::ScheduleComponents;
-
+pub use error::CrontabError;
 // Re-exports.
 pub use time::Tm;


### PR DESCRIPTION
Not a big change but
*  having a debug trait can be quite handy at times.
*  exposing the error enum from the crate.
